### PR TITLE
[Bugfix] fix torch.compiled cache hash error

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -357,6 +357,11 @@ class VllmBackend:
             # graph.
 
             factors = []
+            # 0. factors come from the env, for example, The values of
+            #    VLLM_PP_LAYER_PARTITION will affects the computation graph.
+            env_hash = envs.compute_hash()
+            factors.append(env_hash)
+
             # 1. factors come from the vllm_config (it mainly summarizes how the
             #    model is created)
             config_hash = vllm_config.compute_hash()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import os
 import tempfile
 from typing import TYPE_CHECKING, Any, Callable, Optional
@@ -664,3 +665,31 @@ def set_vllm_use_v1(use_v1: bool):
             "explicitly by the user. Please raise this as a Github "
             "Issue and explicitly set VLLM_USE_V1=0 or 1.")
     os.environ["VLLM_USE_V1"] = "1" if use_v1 else "0"
+
+
+def compute_hash() -> str:
+    """
+    WARNING: Whenever a new key is added to this environment
+    variables, ensure that it is included in the factors list if
+    it affects the computation graph.
+    """
+    factors: list[Any] = []
+
+    # summarize environment variables
+    def factorize(name: str):
+        if __getattr__(name):
+            factors.append(__getattr__(name))
+        else:
+            factors.append("None")
+
+    # The values of VLLM_PP_LAYER_PARTITION will
+    # affects the computation graph.
+    factorize("VLLM_PP_LAYER_PARTITION")
+
+    # TODO(DefTruth): hash all environment variables?
+    # for key in environment_variables:
+    #     factorize(key)
+
+    hash_str = hashlib.md5(str(factors).encode()).hexdigest()
+
+    return hash_str


### PR DESCRIPTION

Without this fix, different values of VLLM_PP_LAYER_PARTITION from the environment will generate the same cache hash. However, different values of VLLM_PP_LAYER_PARTITION will affect the generation of the torch.compiled graph. Therefore, setting VLLM_PP_LAYER_PARTITION to a value different from the previous one will lead to a fatal launch error.

- Without this fix

```bash
# first
export VLLM_PP_LAYER_PARTITION="21,20,20"
# launch server 

# on same env
# second
export VLLM_PP_LAYER_PARTITION="22,20,19"
# launch server -> raise error

(RayWorkerWrapper pid=20458, ip=10.189.109.87) INFO 03-15 21:49:48 [backends.py:115] Directly load the compiled graph for shape None from the cache [repeated 23x across cluster]
ERROR 03-15 21:49:52 [core.py:337] EngineCore hit an exception: Traceback (most recent call last):
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/engine/core.py", line 329, in run_engine_core
ERROR 03-15 21:49:52 [core.py:337]     engine_core = EngineCoreProc(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/engine/core.py", line 284, in __init__
ERROR 03-15 21:49:52 [core.py:337]     super().__init__(vllm_config, executor_class, log_stats)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/engine/core.py", line 62, in __init__
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 1249, in _dummy_run
ERROR 03-15 21:49:52 [core.py:337]     hidden_states = model(
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
ERROR 03-15 21:49:52 [core.py:337]     return self._call_impl(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1750, in _call_impl
ERROR 03-15 21:49:52 [core.py:337]     return forward_call(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 688, in forward
ERROR 03-15 21:49:52 [core.py:337]     hidden_states = self.model(input_ids, positions, intermediate_tensors,
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/compilation/decorators.py", line 238, in __call__
ERROR 03-15 21:49:52 [core.py:337]     output = self.compiled_callable(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/_dynamo/eval_frame.py", line 574, in _fn
ERROR 03-15 21:49:52 [core.py:337]     return fn(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 626, in forward
ERROR 03-15 21:49:52 [core.py:337]     def forward(
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
ERROR 03-15 21:49:52 [core.py:337]     return self._call_impl(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1750, in _call_impl
ERROR 03-15 21:49:52 [core.py:337]     return forward_call(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/_dynamo/eval_frame.py", line 745, in _fn
ERROR 03-15 21:49:52 [core.py:337]     return fn(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/fx/graph_module.py", line 822, in call_wrapped
ERROR 03-15 21:49:52 [core.py:337]     return self._wrapped_call(self, *args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/fx/graph_module.py", line 400, in __call__
ERROR 03-15 21:49:52 [core.py:337]     raise e
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/fx/graph_module.py", line 387, in __call__
ERROR 03-15 21:49:52 [core.py:337]     return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
ERROR 03-15 21:49:52 [core.py:337]     return self._call_impl(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1750, in _call_impl
ERROR 03-15 21:49:52 [core.py:337]     return forward_call(*args, **kwargs)
ERROR 03-15 21:49:52 [core.py:337]   File "<eval_with_key>.42", line 375, in forward
ERROR 03-15 21:49:52 [core.py:337]     submod_2 = self.submod_2(getitem_3, s0, getitem_4, l_self_modules_layers_modules_41_modules_post_attention_layernorm_parameters_weight_, l_self_modules_layers_modules_41_modules_mlp_modules_shared_experts_modules_gate_up_proj_parameters_weight_, l_self_modules_layers_modules_41_modules_mlp_modules_shared_experts_modules_gate_up_proj_parameters_weight_scale_inv_, l_self_modules_layers_modules_41_modules_mlp_modules_shared_experts_modules_down_proj_parameters_weight_, l_self_modules_layers_modules_41_modules_mlp_modules_shared_experts_modules_down_proj_parameters_weight_scale_inv_, l_self_modules_layers_modules_41_modules_mlp_modules_gate_parameters_weight_, l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_e_score_correction_bias_, l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_w13_weight_, l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_w2_weight_, l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_w13_weight_scale_inv_, l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_w2_weight_scale_inv_, l_self_modules_layers_modules_42_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_42_modules_self_attn_modules_q_a_proj_parameters_weight_, l_self_modules_layers_modules_42_modules_self_attn_modules_q_a_proj_parameters_weight_scale_inv_, l_self_modules_layers_modules_42_modules_self_attn_modules_q_a_layernorm_parameters_weight_, l_self_modules_layers_modules_42_modules_self_attn_modules_kv_a_proj_with_mqa_parameters_weight_, l_self_modules_layers_modules_42_modules_self_attn_modules_kv_a_proj_with_mqa_parameters_weight_scale_inv_, l_self_modules_layers_modules_42_modules_self_attn_modules_kv_a_layernorm_parameters_weight_);  getitem_3 = getitem_4 = l_self_modules_layers_modules_41_modules_post_attention_layernorm_parameters_weight_ = l_self_modules_layers_modules_41_modules_mlp_modules_shared_experts_modules_gate_up_proj_parameters_weight_ = l_self_modules_layers_modules_41_modules_mlp_modules_shared_experts_modules_gate_up_proj_parameters_weight_scale_inv_ = l_self_modules_layers_modules_41_modules_mlp_modules_shared_experts_modules_down_proj_parameters_weight_ = l_self_modules_layers_modules_41_modules_mlp_modules_shared_experts_modules_down_proj_parameters_weight_scale_inv_ = l_self_modules_layers_modules_41_modules_mlp_modules_gate_parameters_weight_ = l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_e_score_correction_bias_ = l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_w13_weight_ = l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_w2_weight_ = l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_w13_weight_scale_inv_ = l_self_modules_layers_modules_41_modules_mlp_modules_experts_parameters_w2_weight_scale_inv_ = l_self_modules_layers_modules_42_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_42_modules_self_attn_modules_q_a_proj_parameters_weight_ = l_self_modules_layers_modules_42_modules_self_attn_modules_q_a_proj_parameters_weight_scale_inv_ = l_self_modules_layers_modules_42_modules_self_attn_modules_q_a_layernorm_parameters_weight_ = l_self_modules_layers_modules_42_modules_self_attn_modules_kv_a_proj_with_mqa_parameters_weight_ = l_self_modules_layers_modules_42_modules_self_attn_modules_kv_a_proj_with_mqa_parameters_weight_scale_inv_ = l_self_modules_layers_modules_42_modules_self_attn_modules_kv_a_layernorm_parameters_weight_ = None
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/compilation/backends.py", line 601, in __call__
ERROR 03-15 21:49:52 [core.py:337]     return self.compiled_graph_for_general_shape(*args)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/vllm/compilation/compiler_interface.py", line 331, in compiled_graph
ERROR 03-15 21:49:52 [core.py:337]     graph_output = inductor_compiled_graph(list_args)
ERROR 03-15 21:49:52 [core.py:337]   File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/output_code.py", line 466, in __call__
ERROR 03-15 21:49:52 [core.py:337]     return self.current_callable(inputs)
ERROR 03-15 21:49:52 [core.py:337]   File "/root/.cache/vllm/torch_compile_cache/a232175f5e/rank_23_0/inductor_cache/oz/cozjxmxmm2lgstgnl3da3aql54su6ucz3ndplfu5oe2rsatebgbh.py", line 735, in call

```

- With this fix  

```bash
# first
export VLLM_PP_LAYER_PARTITION="21,20,20"
# launch server 

# on same env
# second
export VLLM_PP_LAYER_PARTITION="22,20,19"
# launch server -> compile new graph

[backends.py:414] Using cache directory: /root/.cache/vllm/torch_compile_cache/3dadbac259/rank_20_0 for vLLM's torch.compile [repeated 23x across cluster]
(RayWorkerWrapper pid=27527) INFO 03-16 00:16:35 [backends.py:424] Dynamo bytecode transform time: 5.71 s [repeated 23x across cluster]
```
<!--- pyml disable-next-line no-emphasis-as-heading -->
