### PR TITLE
[Kernel][VIP] support cuda merge_attn_states kernel, max ~3x improved

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ set(VLLM_EXT_SRC
   "csrc/cache_kernels.cu"
   "csrc/attention/paged_attention_v1.cu"
   "csrc/attention/paged_attention_v2.cu"
+  "csrc/attention/merge_attn_states.cu"
   "csrc/pos_encoding_kernels.cu"
   "csrc/activation_kernels.cu"
   "csrc/layernorm_kernels.cu"

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -1,0 +1,164 @@
+#include <optional>
+#include <cuda_runtime.h>
+#include <cmath>
+#include <torch/all.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+// Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
+// can be used to combine partial attention results (in the split-KV case)
+// May loop over num heads for large NUM_TOKENS
+template <const bool LOOP_OVER_HEAD, const bool OUTPUT_LSE>
+__global__ void merge_attn_states_kernel(
+    float* output,      // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    float* output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    const float* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                              // HEAD_SIZE]
+    const float* __restrict__ prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const float* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                              // HEAD_SIZE]
+    const float* __restrict__ suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const uint NUM_TOKENS,                    // NUM_TOKENS
+    const uint NUM_HEADS,                     // NUM QUERY HEADS
+    const uint HEAD_SIZE                      // HEAD_SIZE, 32,48,64,...,512,etc
+) {
+  if constexpr (LOOP_OVER_HEAD) {
+    const uint token_idx = blockIdx.x;
+    const uint thread_idx = threadIdx.x;
+
+#pragma unroll
+    for (uint head_idx = 0; head_idx < NUM_HEADS; ++head_idx) {
+      float p_lse = prefix_lse[head_idx * NUM_TOKENS + token_idx];
+      float s_lse = suffix_lse[head_idx * NUM_TOKENS + token_idx];
+      p_lse =
+          std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
+      s_lse =
+          std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
+
+      const float max_lse = fmaxf(p_lse, s_lse);
+      p_lse = p_lse - max_lse;
+      s_lse = s_lse - max_lse;
+      const float p_se = expf(p_lse);
+      const float s_se = expf(s_lse);
+      const float out_se = p_se + s_se;
+
+      if constexpr (OUTPUT_LSE) {
+        if (output_lse != nullptr) {
+          float out_lse = logf(out_se) + max_lse;
+          output_lse[head_idx * NUM_TOKENS + token_idx] = out_lse;
+        }
+      }
+
+      const uint blk_offset =
+          token_idx * NUM_HEADS * HEAD_SIZE + head_idx * HEAD_SIZE;
+      const uint thr_offset = thread_idx * 4;
+      const float p_scale = p_se / out_se;
+      const float s_scale = s_se / out_se;
+      const float* prefix_output_blk = prefix_output + blk_offset;
+      const float* suffix_output_blk = suffix_output + blk_offset;
+      float* output_blk = output + blk_offset;
+
+      if (thr_offset < HEAD_SIZE) {
+        float4 p_out4 = ((const float4*)(prefix_output_blk))[thr_offset / 4];
+        float4 s_out4 = ((const float4*)(suffix_output_blk))[thr_offset / 4];
+
+        float4 out4 = make_float4(p_out4.x * p_scale + s_out4.x * s_scale,
+                                  p_out4.y * p_scale + s_out4.y * s_scale,
+                                  p_out4.z * p_scale + s_out4.z * s_scale,
+                                  p_out4.w * p_scale + s_out4.w * s_scale);
+        ((float4*)(output_blk))[thr_offset / 4] = out4;
+      }
+    }  // end loop over heads
+  } else {
+    const uint token_idx = blockIdx.x;
+    const uint head_idx = blockIdx.y;
+    const uint thread_idx = threadIdx.x;
+
+    float p_lse = prefix_lse[head_idx * NUM_TOKENS + token_idx];
+    float s_lse = suffix_lse[head_idx * NUM_TOKENS + token_idx];
+    p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
+    s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
+
+    const float max_lse = fmaxf(p_lse, s_lse);
+    p_lse = p_lse - max_lse;
+    s_lse = s_lse - max_lse;
+    const float p_se = expf(p_lse);
+    const float s_se = expf(s_lse);
+    const float out_se = p_se + s_se;
+
+    if constexpr (OUTPUT_LSE) {
+      if (output_lse != nullptr) {
+        float out_lse = logf(out_se) + max_lse;
+        output_lse[head_idx * NUM_TOKENS + token_idx] = out_lse;
+      }
+    }
+
+    const uint blk_offset =
+        token_idx * NUM_HEADS * HEAD_SIZE + head_idx * HEAD_SIZE;
+    const uint thr_offset = thread_idx * 4;
+    const float p_scale = p_se / out_se;
+    const float s_scale = s_se / out_se;
+    const float* prefix_output_blk = prefix_output + blk_offset;
+    const float* suffix_output_blk = suffix_output + blk_offset;
+    float* output_blk = output + blk_offset;
+
+    if (thr_offset < HEAD_SIZE) {
+      float4 p_out4 = ((const float4*)(prefix_output_blk))[thr_offset / 4];
+      float4 s_out4 = ((const float4*)(suffix_output_blk))[thr_offset / 4];
+
+      float4 out4 = make_float4(p_out4.x * p_scale + s_out4.x * s_scale,
+                                p_out4.y * p_scale + s_out4.y * s_scale,
+                                p_out4.z * p_scale + s_out4.z * s_scale,
+                                p_out4.w * p_scale + s_out4.w * s_scale);
+
+      ((float4*)(output_blk))[thr_offset / 4] = out4;
+    }
+  }
+}
+
+#define LAUNCHE_MERGE_ATTN_STATES_KERNEL(LOOP_OVER_HEAD, OUTPUT_LSE)       \
+  {                                                                        \
+    merge_attn_states_kernel<LOOP_OVER_HEAD, OUTPUT_LSE><<<grid, block>>>( \
+        output.data_ptr<float>(), output_lse_ptr,                          \
+        prefix_output.data_ptr<float>(), prefix_lse.data_ptr<float>(),     \
+        suffix_output.data_ptr<float>(), suffix_lse.data_ptr<float>(),     \
+        NUM_TOKENS, NUM_HEADS, HEAD_SIZE);                                 \
+  }
+
+void merge_attn_states(
+    torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    std::optional<torch::Tensor> output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    const torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const torch::Tensor& suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const bool disable_loop_over_head) {
+  const uint NUM_TOKENS = output.size(0);
+  const uint NUM_HEADS = output.size(1);  // num query heads
+  const uint HEAD_SIZE = output.size(2);
+  assert(HEAD_SIZE % 4 == 0);     // headsize must be multiple of 4
+  assert(HEAD_SIZE / 4 <= 1024);  // headsize must be <= of 4096
+  float* output_lse_ptr = nullptr;
+  if (output_lse.has_value()) {
+    output_lse_ptr = output_lse.value().data_ptr<float>();
+  }
+
+  if (NUM_TOKENS <= 1024 || NUM_HEADS >= 64 || disable_loop_over_head) {
+    dim3 grid(NUM_TOKENS, NUM_HEADS);
+    dim3 block(HEAD_SIZE / 4);
+    if (output_lse_ptr != nullptr) {
+      LAUNCHE_MERGE_ATTN_STATES_KERNEL(false, true);
+    } else {
+      LAUNCHE_MERGE_ATTN_STATES_KERNEL(false, false);
+    }
+  } else {
+    // try loop over num heads for large NUM_TOKENS
+    dim3 grid(NUM_TOKENS);
+    dim3 block(HEAD_SIZE / 4);
+    if (output_lse_ptr != nullptr) {
+      LAUNCHE_MERGE_ATTN_STATES_KERNEL(true, true);
+    } else {
+      LAUNCHE_MERGE_ATTN_STATES_KERNEL(true, false);
+    }
+  }
+}

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -52,6 +52,16 @@ void paged_attention_v2(
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
     const int64_t blocksparse_head_sliding_step);
 
+#ifndef USE_ROCM
+void merge_attn_states(torch::Tensor& output,
+                       std::optional<torch::Tensor> output_lse,
+                       const torch::Tensor& prefix_output,
+                       const torch::Tensor& prefix_lse,
+                       const torch::Tensor& suffix_output,
+                       const torch::Tensor& suffix_lse,
+                       const bool disable_loop_over_head);
+#endif
+
 void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
               double epsilon);
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -64,6 +64,20 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    int blocksparse_head_sliding_step) -> ()");
   ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);
 
+  // Merge attn states
+  // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
+  // can be used to combine partial attention results (in the split-KV case)
+  ops.def(
+      "merge_attn_states("
+      "    Tensor! output,"
+      "    Tensor!? output_lse,"
+      "    Tensor prefix_output,"
+      "    Tensor prefix_lse,"
+      "    Tensor suffix_output,"
+      "    Tensor suffix_lse,"
+      "    bool disable_loop_over_head) -> ()");
+  ops.impl("merge_attn_states", torch::kCUDA, &merge_attn_states);
+
   // Activation ops
   // Activation function used in SwiGLU.
   ops.def("silu_and_mul(Tensor! out, Tensor input) -> ()");

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from vllm._custom_ops import merge_attn_states as merge_attn_states_cuda
+from vllm.attention.ops.triton_merge_attn_states import (
+    merge_attn_states as merge_attn_states_triton)
+from vllm.platforms import current_platform
+
+NUM_TOKENS = [512, 613, 1024, 1536, 4096, 8192]
+# NUM_TOKENS = [512]
+NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
+# NUM_QUERY_HEADS = [16]
+HEAD_SIZES = [32, 48, 64, 96, 128, 256]
+# HEAD_SIZES = [128]
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_query_heads", NUM_QUERY_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@torch.inference_mode()
+def test_merge_attn_states(num_tokens: int, num_query_heads: int,
+                           head_size: int):
+    if not current_platform.is_cuda():
+        pytest.skip('Currently only support compare triton merge_attn_states '
+                    'with custom cuda merge_attn_states kernel')
+
+    # Set test parameters
+    NUM_TOKENS = num_tokens
+    # Num query heads
+    NUM_HEADS = num_query_heads
+    # Set HEAD_SIZE to a power of 2 in the test code
+    HEAD_SIZE = head_size
+
+    # Generate test inputs
+    # prefix_lse and suffix_lse contain inf and normal values
+    prefix_lse = torch.randn(NUM_HEADS,
+                             NUM_TOKENS,
+                             dtype=torch.float32,
+                             device="cuda")
+    suffix_lse = torch.randn(NUM_HEADS,
+                             NUM_TOKENS,
+                             dtype=torch.float32,
+                             device="cuda")
+
+    # Generate boolean masks
+    mask_prefix = torch.rand(NUM_HEADS, NUM_TOKENS) < 0.1
+    mask_suffix = torch.rand(NUM_HEADS, NUM_TOKENS) < 0.1
+    # Ensure that the same position is not True at the same time
+    combined_mask = torch.logical_and(mask_prefix, mask_suffix)
+    mask_prefix = torch.logical_and(mask_prefix, ~combined_mask)
+    mask_suffix = torch.logical_and(mask_suffix, ~combined_mask)
+
+    prefix_lse[mask_prefix] = float('inf')
+    suffix_lse[mask_suffix] = float('inf')
+
+    # Other input tensors (need to be initialized but
+    # no actual calculation needed)
+    output = torch.zeros((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
+                         dtype=torch.float32,
+                         device="cuda")
+    output_lse = torch.zeros((NUM_HEADS, NUM_TOKENS),
+                             dtype=torch.float32,
+                             device="cuda")
+    prefix_output = torch.randn((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
+                                dtype=torch.float32,
+                                device="cuda")
+    suffix_output = torch.randn((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
+                                dtype=torch.float32,
+                                device="cuda")
+
+    output_ref = output.clone()
+    output_lse_ref = output_lse.clone()
+
+    # Run the Triton kernel
+    # Warmup and measure performance of merge_attn_states_triton
+    warmup_times = 2
+    repeat_times = 20
+    total_time_kernel = 0
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    # Warmup
+    for _ in range(warmup_times):
+        merge_attn_states_triton(output_ref, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse, output_lse_ref)
+    torch.cuda.synchronize()
+
+    # Repeat and measure
+    for _ in range(repeat_times):
+        start.record()
+        merge_attn_states_triton(output_ref, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse, output_lse_ref)
+        end.record()
+        torch.cuda.synchronize()
+        total_time_kernel += start.elapsed_time(end)
+
+    avg_time_kernel = total_time_kernel / repeat_times
+
+    # Warmup and measure performance of merge_attn_states_cuda
+    total_time_kernel_cuda = 0
+    output_cuda = output.clone()
+    output_lse_cuda = output_lse.clone()
+
+    # Warmup
+    for _ in range(warmup_times):
+        merge_attn_states_cuda(output_cuda, prefix_output, prefix_lse,
+                               suffix_output, suffix_lse, output_lse_cuda)
+    torch.cuda.synchronize()
+
+    # Repeat and measure
+    for _ in range(repeat_times):
+        start.record()
+        merge_attn_states_cuda(output_cuda, prefix_output, prefix_lse,
+                               suffix_output, suffix_lse, output_lse_cuda)
+        end.record()
+        torch.cuda.synchronize()
+        total_time_kernel_cuda += start.elapsed_time(end)
+
+    avg_time_kernel_cuda = total_time_kernel_cuda / repeat_times
+    print(f"\nNUM_TOKENS:{NUM_TOKENS}, NUM_HEADS:{NUM_HEADS}, "
+          f"HEAD_SIZE:{HEAD_SIZE}, "
+          f"Device: {current_platform.get_device_name()}")
+    print(f"Average time taken by Triton merge_attn_states "
+          f"kernel: {avg_time_kernel} ms")
+    print(f"Average time taken by   CUDA merge_attn_states "
+          f"kernel: {avg_time_kernel_cuda} ms")
+    print("-" * 100)
+
+    if not torch.allclose(output_ref, output_cuda, rtol=1e-3, atol=1e-3):
+        diff = torch.abs(output_ref - output_cuda)
+        max_diff = torch.max(diff)
+        max_diff_index = torch.argmax(diff)
+        print(f"Max difference in output: {max_diff} "
+              f"at index {max_diff_index}")
+        print(f"Triton output at max diff index: "
+              f"{output_ref.flatten()[max_diff_index]}")
+        print(f"CUDA output at max diff index: "
+              f"{output_cuda.flatten()[max_diff_index]}")
+    assert torch.allclose(output_ref, output_cuda, rtol=1e-3,
+                          atol=1e-3), \
+           "Output of Triton and CUDA do not match."
+    print("Output of Triton and CUDA all match.")
+
+    if not torch.allclose(
+            output_lse_ref, output_lse_cuda, rtol=1e-3, atol=1e-3):
+        diff = torch.abs(output_lse_ref - output_lse_cuda)
+        max_diff = torch.max(diff)
+        max_diff_index = torch.argmax(diff)
+        print(f"Max difference in output_lse: "
+              f"{max_diff} at index {max_diff_index}")
+        print(f"Triton output_lse at max diff index: "
+              f"{output_lse_ref.flatten()[max_diff_index]}")
+        print(f"CUDA output_lse at max diff index: "
+              f"{output_lse_cuda.flatten()[max_diff_index]}")
+    assert torch.allclose(
+        output_lse_ref, output_lse_cuda, rtol=1e-3,
+        atol=1e-3), "Output_lse of Triton and CUDA do not match."
+    print("Output LSE of Triton and CUDA all match.")
+
+    print("All output values test passed! All inf values "
+          "are correctly replaced with -inf.")
+    print("-" * 100)

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -7,12 +7,9 @@ from vllm.attention.ops.triton_merge_attn_states import (
     merge_attn_states as merge_attn_states_triton)
 from vllm.platforms import current_platform
 
-NUM_TOKENS = [512, 613, 1024, 1536, 4096, 8192]
-# NUM_TOKENS = [512]
+NUM_TOKENS = [256, 512, 613, 1024, 1536, 4096, 8192, 16384]
 NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
-# NUM_QUERY_HEADS = [16]
-HEAD_SIZES = [32, 48, 64, 96, 128, 256]
-# HEAD_SIZES = [128]
+HEAD_SIZES = [48, 64, 96, 128, 256]
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
@@ -118,13 +115,15 @@ def test_merge_attn_states(num_tokens: int, num_query_heads: int,
         total_time_kernel_cuda += start.elapsed_time(end)
 
     avg_time_kernel_cuda = total_time_kernel_cuda / repeat_times
+    performance_improved = avg_time_kernel / avg_time_kernel_cuda
     print(f"\nNUM_TOKENS:{NUM_TOKENS}, NUM_HEADS:{NUM_HEADS}, "
           f"HEAD_SIZE:{HEAD_SIZE}, "
           f"Device: {current_platform.get_device_name()}")
     print(f"Average time taken by Triton merge_attn_states "
-          f"kernel: {avg_time_kernel} ms")
+          f"kernel: {avg_time_kernel}ms")
     print(f"Average time taken by   CUDA merge_attn_states "
-          f"kernel: {avg_time_kernel_cuda} ms")
+          f"kernel: {avg_time_kernel_cuda}ms, "
+          f"Performance: {performance_improved:.5f}x")
     print("-" * 100)
 
     if not torch.allclose(output_ref, output_cuda, rtol=1e-3, atol=1e-3):

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -138,6 +138,19 @@ def mla_decode_kvcache_cpu(
                                         block_tables, seq_lens)
 
 
+# merge attn states ops
+def merge_attn_states(output: torch.Tensor,
+                      prefix_output: torch.Tensor,
+                      prefix_lse: torch.Tensor,
+                      suffix_output: torch.Tensor,
+                      suffix_lse: torch.Tensor,
+                      output_lse: Optional[torch.Tensor] = None,
+                      disable_loop_over_head: bool = False) -> None:
+    torch.ops._C.merge_attn_states(output, output_lse, prefix_output,
+                                   prefix_lse, suffix_output, suffix_lse,
+                                   disable_loop_over_head)
+
+
 # pos encoding ops
 def rotary_embedding(
     positions: torch.Tensor,

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -204,6 +204,7 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionLayer,
 from vllm.attention.backends.utils import (PAD_SLOT_ID, compute_slot_mapping,
                                            compute_slot_mapping_start_idx,
                                            is_block_tables_empty)
+from vllm.attention.ops.merge_attn_states import merge_attn_states
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase, RowParallelLinear,
                                                UnquantizedLinearMethod)
@@ -217,9 +218,7 @@ from vllm.vllm_flash_attn.fa_utils import get_flash_attn_version
 
 if HAS_TRITON:
     from vllm.attention.ops.triton_flash_attention import triton_attention
-    from vllm.attention.ops.triton_merge_attn_states import merge_attn_states
 else:
-    merge_attn_states = None
     triton_attention = None
 
 try:

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
+import torch
+
+from vllm.platforms import current_platform
+
+
+def merge_attn_states(
+    output: torch.Tensor,
+    prefix_output: torch.Tensor,
+    prefix_lse: torch.Tensor,
+    suffix_output: torch.Tensor,
+    suffix_lse: torch.Tensor,
+    output_lse: Optional[torch.Tensor] = None,
+) -> None:
+    if current_platform.is_cuda():
+        from vllm._custom_ops import merge_attn_states
+        return merge_attn_states(output, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse, output_lse)
+    else:
+        from vllm.attention.ops.triton_merge_attn_states import (
+            merge_attn_states)
+        return merge_attn_states(output, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse, output_lse)


### PR DESCRIPTION
base on [vllm/attention/ops/triton_merge_attn_states.py](https://github.com/vllm-project/vllm/blob/main/vllm/attention/ops/triton_merge_attn_states.py)

Use CUDA kernel instead of Triton to minimize CPU overhead. Compared to the Triton kernel, the CUDA kernel implemented in this PR can achieve a maximum speedup of over `3x`. 
- some pytest 

```bash
pytest -s test_merge_attn_states.py
================================================================================== test session starts ===================================================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /workspace/dev/vipshop/tmp/tests/kernels
plugins: anyio-4.9.0, langsmith-0.3.18, forked-1.6.0, shard-0.1.2, buildkite-test-collector-0.1.9, mock-3.14.0, asyncio-0.24.0, rerunfailures-14.0
asyncio: mode=strict, default_loop_scope=None
collected 240 items
Running 240 items in this shard

test_merge_attn_states.py
NUM_TOKENS:256, NUM_HEADS:4, HEAD_SIZE:48, Device: NVIDIA L20
Average time taken by Triton merge_attn_states kernel: 0.061179200559854506ms
Average time taken by   CUDA merge_attn_states kernel: 0.018688000086694957ms, Performance: 3.27372x
----------------------------------------------------------------------------------------------------
Output of Triton and CUDA all match.
Output LSE of Triton and CUDA all match.
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
.
NUM_TOKENS:512, NUM_HEADS:4, HEAD_SIZE:48, Device: NVIDIA L20
Average time taken by Triton merge_attn_states kernel: 0.058416000567376614ms
Average time taken by   CUDA merge_attn_states kernel: 0.01884320005774498ms, Performance: 3.10011x
----------------------------------------------------------------------------------------------------
Output of Triton and CUDA all match.
Output LSE of Triton and CUDA all match.
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
.
NUM_TOKENS:613, NUM_HEADS:4, HEAD_SIZE:48, Device: NVIDIA L20
Average time taken by Triton merge_attn_states kernel: 0.05683200024068356ms
Average time taken by   CUDA merge_attn_states kernel: 0.01843680050224066ms, Performance: 3.08253x
----------------------------------------------------------------------------------------------------
Output of Triton and CUDA all match.
Output LSE of Triton and CUDA all match.
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------
.
NUM_TOKENS:512, NUM_HEADS:16, HEAD_SIZE:128, Device: NVIDIA L20
Average time taken by Triton merge_attn_states kernel: 0.051609599962830544ms
Average time taken by   CUDA merge_attn_states kernel: 0.0159791998565197ms, Performance: 3.22980x
----------------------------------------------------------------------------------------------------
Output of Triton and CUDA all match.
Output LSE of Triton and CUDA all match.
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
.
NUM_TOKENS:613, NUM_HEADS:16, HEAD_SIZE:128, Device: NVIDIA L20
Average time taken by Triton merge_attn_states kernel: 0.0509856004267931ms
Average time taken by   CUDA merge_attn_states kernel: 0.016385599877685307ms, Performance: 3.11161x
----------------------------------------------------------------------------------------------------
Output of Triton and CUDA all match.
Output LSE of Triton and CUDA all match.
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
.
NUM_TOKENS:1024, NUM_HEADS:16, HEAD_SIZE:128, Device: NVIDIA L20
Average time taken by Triton merge_attn_states kernel: 0.05104639921337366ms
Average time taken by   CUDA merge_attn_states kernel: 0.017299200221896172ms, Performance: 2.95080x
----------------------------------------------------------------------------------------------------
Output of Triton and CUDA all match.
Output LSE of Triton and CUDA all match.
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
================================================================================== 240 passed in 5.96s ===================================================================================
```
