### PR TITLE
[Kernel][VIP] dispatch merge_attn_states cuda kernel, half&bf16

### DIFF
--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -116,7 +116,7 @@ __global__ void merge_attn_states_kernel(
   }
 }
 
-#define LAUNCHE_MERGE_ATTN_STATES_KERNEL(LOOP_OVER_HEAD, OUTPUT_LSE)       \
+#define LAUNCH_MERGE_ATTN_STATES_KERNEL(LOOP_OVER_HEAD, OUTPUT_LSE)        \
   {                                                                        \
     merge_attn_states_kernel<LOOP_OVER_HEAD, OUTPUT_LSE><<<grid, block>>>( \
         output.data_ptr<float>(), output_lse_ptr,                          \
@@ -147,18 +147,18 @@ void merge_attn_states(
     dim3 grid(NUM_TOKENS, NUM_HEADS);
     dim3 block(HEAD_SIZE / 4);
     if (output_lse_ptr != nullptr) {
-      LAUNCHE_MERGE_ATTN_STATES_KERNEL(false, true);
+      LAUNCH_MERGE_ATTN_STATES_KERNEL(false, true);
     } else {
-      LAUNCHE_MERGE_ATTN_STATES_KERNEL(false, false);
+      LAUNCH_MERGE_ATTN_STATES_KERNEL(false, false);
     }
   } else {
     // try loop over num heads for large NUM_TOKENS
     dim3 grid(NUM_TOKENS);
     dim3 block(HEAD_SIZE / 4);
     if (output_lse_ptr != nullptr) {
-      LAUNCHE_MERGE_ATTN_STATES_KERNEL(true, true);
+      LAUNCH_MERGE_ATTN_STATES_KERNEL(true, true);
     } else {
-      LAUNCHE_MERGE_ATTN_STATES_KERNEL(true, false);
+      LAUNCH_MERGE_ATTN_STATES_KERNEL(true, false);
     }
   }
 }

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -1,35 +1,44 @@
 #include <optional>
-#include <cuda_runtime.h>
-#include <cmath>
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <algorithm>
+
+#include "attention_dtypes.h"
+#include "attention_utils.cuh"
+
+namespace vllm {
 
 // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 // can be used to combine partial attention results (in the split-KV case)
-// May loop over num heads for large NUM_TOKENS
-template <const bool LOOP_OVER_HEAD, const bool OUTPUT_LSE>
+template <typename scalar_t, vllm::Fp8KVCacheDataType KV_DTYPE,
+          bool LOOP_OVER_HEAD>
 __global__ void merge_attn_states_kernel(
-    float* output,      // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    scalar_t* output,   // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     float* output_lse,  // [NUM_HEADS, NUM_TOKENS]
-    const float* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
-                                              // HEAD_SIZE]
-    const float* __restrict__ prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
-    const float* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
-                                              // HEAD_SIZE]
-    const float* __restrict__ suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
-    const uint NUM_TOKENS,                    // NUM_TOKENS
-    const uint NUM_HEADS,                     // NUM QUERY HEADS
-    const uint HEAD_SIZE                      // HEAD_SIZE, 32,48,64,...,512,etc
+    const scalar_t* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                                 // HEAD_SIZE]
+    const float* __restrict__ prefix_lse,        // [NUM_HEADS, NUM_TOKENS]
+    const scalar_t* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                                 // HEAD_SIZE]
+    const float* __restrict__ suffix_lse,        // [NUM_HEADS, NUM_TOKENS]
+    const uint num_tokens,                       // NUM_TOKENS
+    const uint num_heads,                        // NUM QUERY HEADS
+    const uint head_size  // HEAD_SIZE, 32,48,64,...,512,etc
 ) {
+  // TODO(DefTruth): may need to support fp8?
+  static_assert(KV_DTYPE == Fp8KVCacheDataType::kAuto,
+                "Currently merge_attn_states_kernel is not support for FP8.");
+
   if constexpr (LOOP_OVER_HEAD) {
+    // May loop over num heads for large NUM_TOKENS
     const uint token_idx = blockIdx.x;
     const uint thread_idx = threadIdx.x;
 
 #pragma unroll
-    for (uint head_idx = 0; head_idx < NUM_HEADS; ++head_idx) {
-      float p_lse = prefix_lse[head_idx * NUM_TOKENS + token_idx];
-      float s_lse = suffix_lse[head_idx * NUM_TOKENS + token_idx];
+    for (uint head_idx = 0; head_idx < num_heads; ++head_idx) {
+      float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
+      float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
       p_lse =
           std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
       s_lse =
@@ -42,40 +51,60 @@ __global__ void merge_attn_states_kernel(
       const float s_se = expf(s_lse);
       const float out_se = p_se + s_se;
 
-      if constexpr (OUTPUT_LSE) {
-        if (output_lse != nullptr) {
-          float out_lse = logf(out_se) + max_lse;
-          output_lse[head_idx * NUM_TOKENS + token_idx] = out_lse;
-        }
+      if (output_lse != nullptr) {
+        float out_lse = logf(out_se) + max_lse;
+        output_lse[head_idx * num_tokens + token_idx] = out_lse;
       }
 
       const uint blk_offset =
-          token_idx * NUM_HEADS * HEAD_SIZE + head_idx * HEAD_SIZE;
-      const uint thr_offset = thread_idx * 4;
+          token_idx * num_heads * head_size + head_idx * head_size;
+      const scalar_t* prefix_output_blk = prefix_output + blk_offset;
+      const scalar_t* suffix_output_blk = suffix_output + blk_offset;
+      scalar_t* output_blk = output + blk_offset;
+
+      // float -> 4, half/bf16 -> 8
+      using pack_128b_t = uint4;
+      constexpr uint pack_size = 16 / sizeof(scalar_t);
+
+      const uint thr_offset = thread_idx * pack_size;
       const float p_scale = p_se / out_se;
       const float s_scale = s_se / out_se;
-      const float* prefix_output_blk = prefix_output + blk_offset;
-      const float* suffix_output_blk = suffix_output + blk_offset;
-      float* output_blk = output + blk_offset;
 
-      if (thr_offset < HEAD_SIZE) {
-        float4 p_out4 = ((const float4*)(prefix_output_blk))[thr_offset / 4];
-        float4 s_out4 = ((const float4*)(suffix_output_blk))[thr_offset / 4];
+      if (thr_offset < head_size) {
+        // Pack 128b load
+        pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
+            prefix_output_blk)[thr_offset / pack_size];
+        pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
+            suffix_output_blk)[thr_offset / pack_size];
+        pack_128b_t o_out_pack;
 
-        float4 out4 = make_float4(p_out4.x * p_scale + s_out4.x * s_scale,
-                                  p_out4.y * p_scale + s_out4.y * s_scale,
-                                  p_out4.z * p_scale + s_out4.z * s_scale,
-                                  p_out4.w * p_scale + s_out4.w * s_scale);
-        ((float4*)(output_blk))[thr_offset / 4] = out4;
+#pragma unroll
+        for (uint i = 0; i < pack_size; ++i) {
+          // Always use float for FMA to keep precision.
+          // half(uint16_t), bfloat16, float -> float.
+          const float p_out_f =
+              vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+          const float s_out_f =
+              vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
+          // fma: a * b + c = p_out_f * p_scale + (s_out_f * s_scale)
+          const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
+          // float -> half(uint16_t), bfloat16, float.
+          vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i],
+                           o_out_f);
+        }
+
+        // Pack 128b storage
+        reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
+            o_out_pack;
       }
-    }  // end loop over heads
+    }  // End loop over heads
   } else {
     const uint token_idx = blockIdx.x;
     const uint head_idx = blockIdx.y;
     const uint thread_idx = threadIdx.x;
 
-    float p_lse = prefix_lse[head_idx * NUM_TOKENS + token_idx];
-    float s_lse = suffix_lse[head_idx * NUM_TOKENS + token_idx];
+    float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
+    float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
     p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
     s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
 
@@ -86,43 +115,124 @@ __global__ void merge_attn_states_kernel(
     const float s_se = expf(s_lse);
     const float out_se = p_se + s_se;
 
-    if constexpr (OUTPUT_LSE) {
-      if (output_lse != nullptr) {
-        float out_lse = logf(out_se) + max_lse;
-        output_lse[head_idx * NUM_TOKENS + token_idx] = out_lse;
-      }
+    if (output_lse != nullptr) {
+      float out_lse = logf(out_se) + max_lse;
+      output_lse[head_idx * num_tokens + token_idx] = out_lse;
     }
 
     const uint blk_offset =
-        token_idx * NUM_HEADS * HEAD_SIZE + head_idx * HEAD_SIZE;
-    const uint thr_offset = thread_idx * 4;
+        token_idx * num_heads * head_size + head_idx * head_size;
+    const scalar_t* prefix_output_blk = prefix_output + blk_offset;
+    const scalar_t* suffix_output_blk = suffix_output + blk_offset;
+    scalar_t* output_blk = output + blk_offset;
+
+    // float -> 4, half/bf16 -> 8
+    using pack_128b_t = uint4;  // 16 bytes
+    constexpr uint pack_size = 16 / sizeof(scalar_t);
+
+    const uint thr_offset = thread_idx * pack_size;
     const float p_scale = p_se / out_se;
     const float s_scale = s_se / out_se;
-    const float* prefix_output_blk = prefix_output + blk_offset;
-    const float* suffix_output_blk = suffix_output + blk_offset;
-    float* output_blk = output + blk_offset;
 
-    if (thr_offset < HEAD_SIZE) {
-      float4 p_out4 = ((const float4*)(prefix_output_blk))[thr_offset / 4];
-      float4 s_out4 = ((const float4*)(suffix_output_blk))[thr_offset / 4];
+    if (thr_offset < head_size) {
+      // Pack 128b load
+      pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
+          prefix_output_blk)[thr_offset / pack_size];
+      pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
+          suffix_output_blk)[thr_offset / pack_size];
+      pack_128b_t o_out_pack;
 
-      float4 out4 = make_float4(p_out4.x * p_scale + s_out4.x * s_scale,
-                                p_out4.y * p_scale + s_out4.y * s_scale,
-                                p_out4.z * p_scale + s_out4.z * s_scale,
-                                p_out4.w * p_scale + s_out4.w * s_scale);
+#pragma unroll
+      for (uint i = 0; i < pack_size; ++i) {
+        // Always use float for FMA to keep precision.
+        // half(uint16_t), bfloat16, float -> float.
+        const float p_out_f =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+        const float s_out_f =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
+        // fma: a * b + c = p_out_f * p_scale + (s_out_f * s_scale)
+        const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
+        // float -> half(uint16_t), bfloat16, float.
+        vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i], o_out_f);
+      }
 
-      ((float4*)(output_blk))[thr_offset / 4] = out4;
+      // Pack 128b storage
+      reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
+          o_out_pack;
     }
   }
 }
 
-#define LAUNCH_MERGE_ATTN_STATES_KERNEL(LOOP_OVER_HEAD, OUTPUT_LSE)        \
-  {                                                                        \
-    merge_attn_states_kernel<LOOP_OVER_HEAD, OUTPUT_LSE><<<grid, block>>>( \
-        output.data_ptr<float>(), output_lse_ptr,                          \
-        prefix_output.data_ptr<float>(), prefix_lse.data_ptr<float>(),     \
-        suffix_output.data_ptr<float>(), suffix_lse.data_ptr<float>(),     \
-        NUM_TOKENS, NUM_HEADS, HEAD_SIZE);                                 \
+}  // namespace vllm
+
+// The following macro is used to dispatch the conversion function based on
+// the output data type. The FN is a macro that calls a function with
+// template<typename SCALAR_T, KV_DTYPE>.
+#define DISPATCH_BY_SCALAR_DTYPE(SCALAR_DTYPE, FN)                      \
+  {                                                                     \
+    if (SCALAR_DTYPE == at::ScalarType::Float) {                        \
+      FN(float, vllm::Fp8KVCacheDataType::kAuto);                       \
+    } else if (SCALAR_DTYPE == at::ScalarType::Half) {                  \
+      FN(uint16_t, vllm::Fp8KVCacheDataType::kAuto);                    \
+    } else if (SCALAR_DTYPE == at::ScalarType::BFloat16) {              \
+      FN(__nv_bfloat16, vllm::Fp8KVCacheDataType::kAuto);               \
+    } else {                                                            \
+      TORCH_CHECK(false, "Unsupported data type of O: ", SCALAR_DTYPE); \
+    }                                                                   \
+  }
+
+#define LAUNCH_MERGE_ATTN_STATES(SCALAR_T, KV_DTYPE, LOOP_OVER_HEAD)        \
+  {                                                                         \
+    vllm::merge_attn_states_kernel<SCALAR_T, KV_DTYPE, LOOP_OVER_HEAD>      \
+        <<<grid, block>>>(                                                  \
+            reinterpret_cast<SCALAR_T*>(output.data_ptr()), output_lse_ptr, \
+            reinterpret_cast<SCALAR_T*>(prefix_output.data_ptr()),          \
+            reinterpret_cast<float*>(prefix_lse.data_ptr()),                \
+            reinterpret_cast<SCALAR_T*>(suffix_output.data_ptr()),          \
+            reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,    \
+            num_heads, head_size);                                          \
+  }
+
+template <typename SCALAR_T, vllm::Fp8KVCacheDataType KV_DTYPE>
+void merge_attn_states_launcher(
+    torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    std::optional<torch::Tensor> output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    const torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const torch::Tensor& suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const bool disable_loop_over_head) {
+  const uint num_tokens = output.size(0);
+  const uint num_heads = output.size(1);  // num query heads
+  const uint head_size = output.size(2);
+  // float -> 4, half/bf16 -> 8, 128b = 16 bytes.
+  constexpr uint pack_size = 16 / sizeof(SCALAR_T);
+  TORCH_CHECK(head_size % pack_size == 0,
+              "headsize must be multiple of pack_size:", pack_size);
+  TORCH_CHECK(head_size / pack_size <= 1024,
+              "headsize/pack_size must be <= of 1024, pack_size: ", pack_size);
+  float* output_lse_ptr = nullptr;
+  if (output_lse.has_value()) {
+    output_lse_ptr = output_lse.value().data_ptr<float>();
+  }
+
+  if (num_tokens <= 1024 || num_heads >= 64 || disable_loop_over_head) {
+    dim3 grid(num_tokens, num_heads);
+    dim3 block(head_size / pack_size);
+    LAUNCH_MERGE_ATTN_STATES(SCALAR_T, KV_DTYPE, false);
+  } else {
+    // try loop over num heads for large NUM_TOKENS
+    dim3 grid(num_tokens);
+    dim3 block(head_size / pack_size);
+    LAUNCH_MERGE_ATTN_STATES(SCALAR_T, KV_DTYPE, true);
+  }
+}
+
+#define CALL_MERGE_ATTN_STATES_LAUNCHER(SCALAR_T, KV_DTYPE)           \
+  {                                                                   \
+    merge_attn_states_launcher<SCALAR_T, KV_DTYPE>(                   \
+        output, output_lse, prefix_output, prefix_lse, suffix_output, \
+        suffix_lse, disable_loop_over_head);                          \
   }
 
 void merge_attn_states(
@@ -133,32 +243,5 @@ void merge_attn_states(
     const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     const torch::Tensor& suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
     const bool disable_loop_over_head) {
-  const uint NUM_TOKENS = output.size(0);
-  const uint NUM_HEADS = output.size(1);  // num query heads
-  const uint HEAD_SIZE = output.size(2);
-  assert(HEAD_SIZE % 4 == 0);     // headsize must be multiple of 4
-  assert(HEAD_SIZE / 4 <= 1024);  // headsize must be <= of 4096
-  float* output_lse_ptr = nullptr;
-  if (output_lse.has_value()) {
-    output_lse_ptr = output_lse.value().data_ptr<float>();
-  }
-
-  if (NUM_TOKENS <= 1024 || NUM_HEADS >= 64 || disable_loop_over_head) {
-    dim3 grid(NUM_TOKENS, NUM_HEADS);
-    dim3 block(HEAD_SIZE / 4);
-    if (output_lse_ptr != nullptr) {
-      LAUNCH_MERGE_ATTN_STATES_KERNEL(false, true);
-    } else {
-      LAUNCH_MERGE_ATTN_STATES_KERNEL(false, false);
-    }
-  } else {
-    // try loop over num heads for large NUM_TOKENS
-    dim3 grid(NUM_TOKENS);
-    dim3 block(HEAD_SIZE / 4);
-    if (output_lse_ptr != nullptr) {
-      LAUNCH_MERGE_ATTN_STATES_KERNEL(true, true);
-    } else {
-      LAUNCH_MERGE_ATTN_STATES_KERNEL(true, false);
-    }
-  }
+  DISPATCH_BY_SCALAR_DTYPE(output.dtype(), CALL_MERGE_ATTN_STATES_LAUNCHER);
 }

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -19,7 +19,7 @@ def merge_attn_states_torch(
         suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
         suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
         output_lse: Optional[torch.Tensor] = None,  # [NUM_HEADS, NUM_TOKENS]
-) -> list[torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     p_lse = prefix_lse
     s_lse = suffix_lse
     # inf -> -inf

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
 import pytest
 import torch
 
@@ -7,29 +9,66 @@ from vllm.attention.ops.triton_merge_attn_states import (
     merge_attn_states as merge_attn_states_triton)
 from vllm.platforms import current_platform
 
-NUM_TOKENS = [256, 512, 613, 1024, 1536, 4096, 8192, 16384]
-NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
-HEAD_SIZES = [48, 64, 96, 128, 256]
+
+# Naive PyTorch Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
+# can be used to combine partial attention results (in the split-KV case)
+def merge_attn_states_torch(
+        output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+        prefix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+        prefix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
+        suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+        suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
+        output_lse: Optional[torch.Tensor] = None,  # [NUM_HEADS, NUM_TOKENS]
+) -> None:
+    p_lse = prefix_lse.clone()
+    s_lse = suffix_lse.clone()
+    # inf -> -inf
+    p_lse[p_lse == torch.inf] = -torch.inf
+    s_lse[s_lse == torch.inf] = -torch.inf
+    # max_lse [NUM_HEADS, NUM_TOKENS]
+    max_lse = torch.maximum(p_lse, s_lse)
+    p_lse = p_lse - max_lse
+    s_lse = s_lse - max_lse
+    p_lse_exp = torch.exp(p_lse)
+    s_lse_exp = torch.exp(s_lse)
+    out_se = (p_lse_exp + s_lse_exp)
+    if output_lse is not None:
+        output_lse = torch.log(out_se) + max_lse
+    p_scale = p_lse_exp / out_se  # [NUM_HEADS, NUM_TOKENS]
+    s_scale = s_lse_exp / out_se  # [NUM_HEADS, NUM_TOKENS]
+    p_scale = torch.transpose(p_scale, 0,
+                              1).unsqueeze(2)  # [NUM_TOKENS, NUM_HEADS, 1]
+    s_scale = torch.transpose(s_scale, 0,
+                              1).unsqueeze(2)  # [NUM_TOKENS, NUM_HEADS, 1]
+    output = prefix_output * p_scale + suffix_output * s_scale
+    return output, output_lse
+
+
+NUM_TOKENS = [256, 512, 613, 1024, 1536, 4096]
+NUM_QUERY_HEADS = [4, 8, 16, 32]
+HEAD_SIZES = [64, 96, 128]
+DTYPES = [torch.float32, torch.half, torch.bfloat16]
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("num_query_heads", NUM_QUERY_HEADS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("output_dtype", DTYPES)
 @torch.inference_mode()
 def test_merge_attn_states(num_tokens: int, num_query_heads: int,
-                           head_size: int):
+                           head_size: int, output_dtype: torch.dtype):
     if not current_platform.is_cuda():
         pytest.skip('Currently only support compare triton merge_attn_states '
                     'with custom cuda merge_attn_states kernel')
 
-    # Set test parameters
     NUM_TOKENS = num_tokens
-    # Num query heads
     NUM_HEADS = num_query_heads
-    # Set HEAD_SIZE to a power of 2 in the test code
     HEAD_SIZE = head_size
 
-    # Generate test inputs
+    print(f"\nNUM_TOKENS:{NUM_TOKENS}, NUM_HEADS:{NUM_HEADS}, "
+          f"HEAD_SIZE:{HEAD_SIZE}, DTYPE: {output_dtype}, "
+          f"Device: {current_platform.get_device_name()}")
+
     # prefix_lse and suffix_lse contain inf and normal values
     prefix_lse = torch.randn(NUM_HEADS,
                              NUM_TOKENS,
@@ -54,108 +93,131 @@ def test_merge_attn_states(num_tokens: int, num_query_heads: int,
     # Other input tensors (need to be initialized but
     # no actual calculation needed)
     output = torch.zeros((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
-                         dtype=torch.float32,
+                         dtype=output_dtype,
                          device="cuda")
     output_lse = torch.zeros((NUM_HEADS, NUM_TOKENS),
                              dtype=torch.float32,
                              device="cuda")
     prefix_output = torch.randn((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
-                                dtype=torch.float32,
+                                dtype=output_dtype,
                                 device="cuda")
     suffix_output = torch.randn((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
-                                dtype=torch.float32,
+                                dtype=output_dtype,
                                 device="cuda")
 
-    output_ref = output.clone()
-    output_lse_ref = output_lse.clone()
-
-    # Run the Triton kernel
-    # Warmup and measure performance of merge_attn_states_triton
     warmup_times = 2
     repeat_times = 20
-    total_time_kernel = 0
+
+    output_torch = output.clone()
+    output_lse_torch = output_lse.clone()
+    total_time_torch_kernel = 0
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
 
-    # Warmup
+    # 0. Run the Torch kernel
     for _ in range(warmup_times):
-        merge_attn_states_triton(output_ref, prefix_output, prefix_lse,
-                                 suffix_output, suffix_lse, output_lse_ref)
+        output_torch, output_lse_torch = merge_attn_states_torch(
+            output_torch, prefix_output, prefix_lse, suffix_output, suffix_lse,
+            output_lse_torch)
     torch.cuda.synchronize()
 
-    # Repeat and measure
     for _ in range(repeat_times):
         start.record()
-        merge_attn_states_triton(output_ref, prefix_output, prefix_lse,
-                                 suffix_output, suffix_lse, output_lse_ref)
+        output_torch, output_lse_torch = merge_attn_states_torch(
+            output_torch, prefix_output, prefix_lse, suffix_output, suffix_lse,
+            output_lse_torch)
         end.record()
         torch.cuda.synchronize()
-        total_time_kernel += start.elapsed_time(end)
+        total_time_torch_kernel += start.elapsed_time(end)
 
-    avg_time_kernel = total_time_kernel / repeat_times
+    avg_time_torch_kernel = total_time_torch_kernel / repeat_times
 
-    # Warmup and measure performance of merge_attn_states_cuda
-    total_time_kernel_cuda = 0
+    # 1. Run the Triton kernel
+    output_ref_triton = output.clone()
+    output_lse_ref_triton = output_lse.clone()
+
+    total_time_triton_kernel = 0
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    for _ in range(warmup_times):
+        merge_attn_states_triton(output_ref_triton, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse,
+                                 output_lse_ref_triton)
+    torch.cuda.synchronize()
+
+    for _ in range(repeat_times):
+        start.record()
+        merge_attn_states_triton(output_ref_triton, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse,
+                                 output_lse_ref_triton)
+        end.record()
+        torch.cuda.synchronize()
+        total_time_triton_kernel += start.elapsed_time(end)
+
+    avg_time_triton_kernel = total_time_triton_kernel / repeat_times
+
+    # 2. Run the CUDA kernel
+    total_time_cuda_kernel = 0
     output_cuda = output.clone()
     output_lse_cuda = output_lse.clone()
 
-    # Warmup
     for _ in range(warmup_times):
         merge_attn_states_cuda(output_cuda, prefix_output, prefix_lse,
                                suffix_output, suffix_lse, output_lse_cuda)
     torch.cuda.synchronize()
 
-    # Repeat and measure
     for _ in range(repeat_times):
         start.record()
         merge_attn_states_cuda(output_cuda, prefix_output, prefix_lse,
                                suffix_output, suffix_lse, output_lse_cuda)
         end.record()
         torch.cuda.synchronize()
-        total_time_kernel_cuda += start.elapsed_time(end)
+        total_time_cuda_kernel += start.elapsed_time(end)
 
-    avg_time_kernel_cuda = total_time_kernel_cuda / repeat_times
-    performance_improved = avg_time_kernel / avg_time_kernel_cuda
-    print(f"\nNUM_TOKENS:{NUM_TOKENS}, NUM_HEADS:{NUM_HEADS}, "
-          f"HEAD_SIZE:{HEAD_SIZE}, "
-          f"Device: {current_platform.get_device_name()}")
-    print(f"Average time taken by Triton merge_attn_states "
-          f"kernel: {avg_time_kernel}ms")
-    print(f"Average time taken by   CUDA merge_attn_states "
-          f"kernel: {avg_time_kernel_cuda}ms, "
+    avg_time_cuda_kernel = total_time_cuda_kernel / repeat_times
+    # 3. Performance compare
+    performance_improved = avg_time_triton_kernel / avg_time_cuda_kernel
+    print(f" Torch time: {avg_time_torch_kernel:.6f}ms")
+    print(f"Triton time: {avg_time_triton_kernel:.6f}ms")
+    print(f"  CUDA time: {avg_time_cuda_kernel:.6f}ms, "
           f"Performance: {performance_improved:.5f}x")
     print("-" * 100)
 
-    if not torch.allclose(output_ref, output_cuda, rtol=1e-3, atol=1e-3):
-        diff = torch.abs(output_ref - output_cuda)
-        max_diff = torch.max(diff)
-        max_diff_index = torch.argmax(diff)
-        print(f"Max difference in output: {max_diff} "
-              f"at index {max_diff_index}")
-        print(f"Triton output at max diff index: "
-              f"{output_ref.flatten()[max_diff_index]}")
-        print(f"CUDA output at max diff index: "
-              f"{output_cuda.flatten()[max_diff_index]}")
-    assert torch.allclose(output_ref, output_cuda, rtol=1e-3,
-                          atol=1e-3), \
-           "Output of Triton and CUDA do not match."
-    print("Output of Triton and CUDA all match.")
+    # 4. Correctness compare
+    # Liger Kernel: Efficient Triton Kernels for LLM Training
+    # https://arxiv.org/pdf/2410.10989, 3.3 Correctness
+    # use rtol = 1e-2 for bfloat16.
+    rtol = 1e-2 if output_dtype == torch.bfloat16 else 1e-3
 
-    if not torch.allclose(
-            output_lse_ref, output_lse_cuda, rtol=1e-3, atol=1e-3):
-        diff = torch.abs(output_lse_ref - output_lse_cuda)
-        max_diff = torch.max(diff)
-        max_diff_index = torch.argmax(diff)
-        print(f"Max difference in output_lse: "
-              f"{max_diff} at index {max_diff_index}")
-        print(f"Triton output_lse at max diff index: "
-              f"{output_lse_ref.flatten()[max_diff_index]}")
-        print(f"CUDA output_lse at max diff index: "
-              f"{output_lse_cuda.flatten()[max_diff_index]}")
-    assert torch.allclose(
-        output_lse_ref, output_lse_cuda, rtol=1e-3,
-        atol=1e-3), "Output_lse of Triton and CUDA do not match."
-    print("Output LSE of Triton and CUDA all match.")
+    def diff(a: torch.Tensor, b: torch.Tensor):
+        max_diff = torch.max(torch.abs(a.float() - b.float()))
+        return max_diff
+
+    # Use Triton output as reference because we want to replace
+    # the Triton kernel with custom CUDA kernel for merge attn
+    # states operation.
+    output_ref = output_ref_triton
+    output_lse_ref = output_lse_ref_triton
+    torch.testing.assert_close(output_cuda.float(),
+                               output_ref.float(),
+                               atol=1e-3,
+                               rtol=rtol)
+    print("Output all match, max abs diff:")
+    print(f" (CUDA  vs Triton): {diff(output_ref, output_cuda)}")
+    print(f"(Triton vs Torch) : {diff(output_torch, output_ref)}")
+    print(f"  (CUDA vs Torch) : {diff(output_torch, output_cuda)}")
+    print("-" * 100)
+
+    torch.testing.assert_close(output_lse_cuda.float(),
+                               output_lse_ref.float(),
+                               atol=1e-3,
+                               rtol=rtol)
+    print("Output LSE all match, max abs diff:")
+    print(f"(Triton vs Torch) : {diff(output_lse_torch, output_lse_ref)}")
+    print(f"  (CUDA vs Torch) : {diff(output_lse_torch, output_lse_cuda)}")
+    print(f" (CUDA  vs Triton): {diff(output_lse_ref, output_lse_cuda)}")
+    print("-" * 100)
 
     print("All output values test passed! All inf values "
           "are correctly replaced with -inf.")

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -19,7 +19,7 @@ def merge_attn_states_torch(
         suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
         suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
         output_lse: Optional[torch.Tensor] = None,  # [NUM_HEADS, NUM_TOKENS]
-) -> tuple[torch.Tensor, torch.Tensor | None]:
+):
     p_lse = prefix_lse
     s_lse = suffix_lse
     # inf -> -inf

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -19,7 +19,7 @@ def merge_attn_states_torch(
         suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
         suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
         output_lse: Optional[torch.Tensor] = None,  # [NUM_HEADS, NUM_TOKENS]
-) -> None:
+) -> list[torch.Tensor]:
     p_lse = prefix_lse
     s_lse = suffix_lse
     # inf -> -inf

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import torch
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
@@ -20,7 +21,9 @@ def merge_attn_states(
     # NOTE(DefTruth): Currently, custom merge_attn_states CUDA kernel
     # is not support for FP8 dtype, fallback to use Triton kernel.
     supported_dtypes = [torch.float32, torch.half, torch.bfloat16]
-    if current_platform.is_cuda() and (output.dtype in supported_dtypes):
+    if ((not envs.VLLM_DISABLE_MERGE_ATTN_CUDA_OP)
+            and current_platform.is_cuda()
+            and (output.dtype in supported_dtypes)):
         from vllm._custom_ops import merge_attn_states
         return merge_attn_states(output, prefix_output, prefix_lse,
                                  suffix_output, suffix_lse, output_lse)

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -3,7 +3,10 @@ from typing import Optional
 
 import torch
 
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
 
 
 def merge_attn_states(
@@ -14,7 +17,10 @@ def merge_attn_states(
     suffix_lse: torch.Tensor,
     output_lse: Optional[torch.Tensor] = None,
 ) -> None:
-    if current_platform.is_cuda():
+    # NOTE(DefTruth): Currently, custom merge_attn_states CUDA kernel
+    # is not support for FP8 dtype, fallback to use Triton kernel.
+    supported_dtypes = [torch.float32, torch.half, torch.bfloat16]
+    if current_platform.is_cuda() and (output.dtype in supported_dtypes):
         from vllm._custom_ops import merge_attn_states
         return merge_attn_states(output, prefix_output, prefix_lse,
                                  suffix_output, suffix_lse, output_lse)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -106,6 +106,7 @@ if TYPE_CHECKING:
     VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION: bool = False
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_USE_DEEP_GEMM: bool = False
+    VLLM_DISABLE_MERGE_ATTN_CUDA_OP: bool = False
 
 
 def get_default_cache_root():
@@ -697,6 +698,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM":
     lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "0"))),
+
+    # Force disable merge_attn_states CUDA op, use Triton kernel.
+    "VLLM_DISABLE_MERGE_ATTN_CUDA_OP":
+    lambda: bool(int(os.getenv("VLLM_DISABLE_MERGE_ATTN_CUDA_OP", "0"))),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

check https://github.com/vllm-project/vllm/pull/16173 for more details.

Use CUDA kernel instead of Triton to minimize CPU overhead. Compared to the Triton kernel, the CUDA kernel implemented in this PR can achieve a maximum speedup of over 3x. End2End performance improved for R1 with PP=3 + TP=8 on L20, 4K IN:1K OUT (TTFT 5687.80 ms -> 5654.02 ms), 8K IN:64 OUT (TTFT 17673.93ms -> 14785.00ms).

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing/overview.html>**
